### PR TITLE
Update flat-database.h - Correct spelling of 'Writting' to 'Writing'

### DIFF
--- a/src/flat-database.h
+++ b/src/flat-database.h
@@ -219,7 +219,7 @@ public:
             }
         }
 
-        LogPrintf("Writting info to %s...\n", strFilename);
+        LogPrintf("Writing info to %s...\n", strFilename);
         Write(objToSave);
         LogPrintf("%s dump finished  %dms\n", strFilename, GetTimeMillis() - nStart);
 


### PR DESCRIPTION
Correct spelling of 'Writting' to 'Writing' in log outputs.