### PR TITLE
v1.4.0.0 - Allow blocks to be minted without MN reward if no consensus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **Credits (CRDS) v1.3.1.0**
+# **Credits (CRDS) v1.4.0.0**
 
 ![CRDS logo](https://github.com/Credits-CRDS/Credits/blob/master/src/qt/res/icons/light/about.png) [![Build Status](https://travis-ci.org/CRDS/Credits.svg?branch=master)](https://travis-ci.org/CRDS/Credits)
 

--- a/credits-qt.pro
+++ b/credits-qt.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = credits
-VERSION = 1.3.1.0
+VERSION = 1.4.0.0
 INCLUDEPATH += src \
                src/crypto \
                src/crypto/heavyhash \

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -8,7 +8,7 @@ $(package)_dependencies=openssl zlib
 $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib
-$(package)_patches=mac-qmake.conf mingw-uuidof.patch pidlist_absolute.patch fix-xcb-include-order.patch fix_qt_pkgconfig.patch
+$(package)_patches=mac-qmake.conf mingw-uuidof.patch pidlist_absolute.patch fix-xcb-include-order.patch fix_qt_pkgconfig.patch fix_qfontengine_coretext.patch fix_qcocoahelpers.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=3a15aebd523c6d89fb97b2d3df866c94149653a26d27a00aac9b6d3020bc5a1d
@@ -139,7 +139,8 @@ define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/mingw-uuidof.patch && \
   patch -p1 < $($(package)_patch_dir)/pidlist_absolute.patch && \
   patch -p1 < $($(package)_patch_dir)/fix-xcb-include-order.patch && \
-  patch -p1 < $($(package)_patch_dir)/fix_qt_pkgconfig.patch && \
+  patch -p1 < $($(package)_patch_dir)/fix_qfontengine_coretext.patch && \
+  patch -p1 < $($(package)_patch_dir)/fix_qcocoahelpers.patch && \  
   echo "!host_build: QMAKE_CFLAGS     += $($(package)_cflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_CXXFLAGS   += $($(package)_cxxflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \

--- a/depends/patches/qt/fix_qcocoahelpers.patch
+++ b/depends/patches/qt/fix_qcocoahelpers.patch
@@ -1,0 +1,28 @@
+index bbb3793..74371d5 100644
+new/qtbase/src/plugins/platforms/cocoa/qcocoahelpers.h
+@@ -80,7 +80,7 @@ QColor qt_mac_toQColor(CGColorRef color);
+ // Creates a mutable shape, it's the caller's responsibility to release.
+ HIMutableShapeRef qt_mac_QRegionToHIMutableShape(const QRegion &region);
+ 
+void qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage);
+ 
+ NSDragOperation qt_mac_mapDropAction(Qt::DropAction action);
+ NSDragOperation qt_mac_mapDropActions(Qt::DropActions actions);
+index cd73148..3f8429e 100644
+new/qtbase/src/plugins/platforms/cocoa/qcocoahelpers.mm
+@@ -544,15 +544,8 @@ NSRect qt_mac_flipRect(const QRect &rect)
+     return NSMakeRect(rect.x(), flippedY, rect.width(), rect.height());
+ }
+ 
+void qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage)
+ {
+     CGContextSaveGState( inContext );
+     CGContextTranslateCTM (inContext, 0, inBounds->origin.y + CGRectGetMaxY(*inBounds));
+     CGContextScaleCTM(inContext, 1, -1);
+@@ -560,10 +553,6 @@ OSStatus qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGIm
+     CGContextDrawImage(inContext, *inBounds, inImage);
+ 
+     CGContextRestoreGState(inContext);
+ }
+ 
+ Qt::MouseButton cocoaButton2QtButton(NSInteger buttonNum)

--- a/depends/patches/qt/fix_qfontengine_coretext.patch
+++ b/depends/patches/qt/fix_qfontengine_coretext.patch
@@ -1,0 +1,10 @@
+index 25ff69d877d..98b753eff96 100644
+new/qtbase/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm
+@@ -824,7 +824,7 @@ void QCoreTextFontEngine::getUnscaledGlyph(glyph_t glyph, QPainterPath *path, gl
+ 
+ QFixed QCoreTextFontEngine::emSquareSize() const
+ {
+    return QFixed(int(CTFontGetUnitsPerEm(ctfont)));
+ }
+ 
+ QFontEngine *QCoreTextFontEngine::cloneWithSize(qreal pixelSize) const

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -116,7 +116,7 @@ public:
         consensus.nHardForkOne = 250000; // block
         consensus.nHardForkTwo = 375000; // block
         consensus.nHardForkThree = 550000; //block
-		consensus.nHardForkFour = 675000; //block
+		consensus.nHardForkFour = 665000; //block
         consensus.nTempDevFundIncreaseEnd = 625000; //block
         consensus.nMasternodePaymentsStartBlock = 100; // Masternode Payments begin on block 100.
         consensus.nInstantSendKeepLock = 24;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -349,7 +349,7 @@ public:
 		consensus.nHardForkOne = 5000;
         consensus.nHardForkTwo = 30000;
         consensus.nHardForkThree = 50000;
-		consensus.nHardForkThree = 60000;
+		consensus.nHardForkFour = 60000;
         consensus.nTempDevFundIncreaseEnd = 55000;
         consensus.nMasternodePaymentsStartBlock = 0;
         consensus.nInstantSendKeepLock = 24;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -116,6 +116,7 @@ public:
         consensus.nHardForkOne = 250000; // block
         consensus.nHardForkTwo = 375000; // block
         consensus.nHardForkThree = 550000; //block
+		consensus.nHardForkFour = 675000; //block
         consensus.nTempDevFundIncreaseEnd = 625000; //block
         consensus.nMasternodePaymentsStartBlock = 100; // Masternode Payments begin on block 100.
         consensus.nInstantSendKeepLock = 24;
@@ -233,6 +234,7 @@ public:
         consensus.nHardForkOne = 5000;
         consensus.nHardForkTwo = 30000;
         consensus.nHardForkThree = 50000;
+		consensus.nHardForkFour = 60000;
         consensus.nTempDevFundIncreaseEnd = 55000;
         consensus.nMasternodePaymentsStartBlock = 0;
         consensus.nInstantSendKeepLock = 24;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -346,6 +346,11 @@ class CRegTestParams : public CChainParams {
 public:
     CRegTestParams() {
         strNetworkID = "regtest";
+		consensus.nHardForkOne = 5000;
+        consensus.nHardForkTwo = 30000;
+        consensus.nHardForkThree = 50000;
+		consensus.nHardForkThree = 60000;
+        consensus.nTempDevFundIncreaseEnd = 55000;
         consensus.nMasternodePaymentsStartBlock = 0;
         consensus.nInstantSendKeepLock = 24;
         consensus.nBudgetPaymentsStartBlock = 1000;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -40,6 +40,7 @@ struct Params {
     int nHardForkOne; // block
     int nHardForkTwo; // block
     int nHardForkThree; //block
+	int nHardForkFour; //block
     int nTempDevFundIncreaseEnd; //block height for temporal Dev fund increase ending
     int nMasternodePaymentsStartBlock;
     int nInstantSendKeepLock; // in blocks

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -225,9 +225,9 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount bloc
 		return true;
     }
 
-	if (nBlockHeight <= consensusParams.nHardForkFour) {
     // Masternodes must be paid with every block after block nHardForkTwo up to nHardForkFour which caused chain to fork
-		LogPrintf("IsBlockPayeeValid -- ERROR: Invalid Masternode payment detected at height %d: %s", nBlockHeight, txNew.ToString());
+	if (nBlockHeight <= consensusParams.nHardForkFour) {
+    	LogPrintf("IsBlockPayeeValid -- ERROR: Invalid Masternode payment detected at height %d: %s", nBlockHeight, txNew.ToString());
 		return false;
 	}
 	

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -773,8 +773,16 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     }
     result.push_back(Pair("masternode", masternodeObj));
     result.push_back(Pair("masternode_payments_started", pindexPrev->nHeight + 1 > Params().GetConsensus().nMasternodePaymentsStartBlock));
-    result.push_back(Pair("masternode_payments_enforced", true));
-
+    
+	// Masternodes must be paid with every block after block nHardForkTwo up to nHardForkFour which caused chain to fork
+	if (nBlockHeight <= consensusParams.nHardForkFour) {
+    	result.push_back(Pair("masternode_payments_enforced", true);
+	}
+	
+	// If Spork 8 is set then Masternode payment is enforced.
+	result.push_back(Pair("masternode_payments_enforced", sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));
+	
+		
     int nNextHeight = chainActive.Height() + 1;
 
     // 0.5 CRDS reward to Dev fund from 625001 until block 1375000

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -776,7 +776,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     
 	// Masternodes must be paid with every block after block nHardForkTwo up to nHardForkFour which caused chain to fork
 	if (nBlockHeight <= consensusParams.nHardForkFour) {
-    	result.push_back(Pair("masternode_payments_enforced", true);
+    	result.push_back(Pair("masternode_payments_enforced", true));
 	}
 	
 	// If Spork 8 is set then Masternode payment is enforced.

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -779,9 +779,10 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         result.push_back(Pair("masternode_payments_enforced", true));
     }
     
-    // If Spork 8 is set then Masternode payment is enforced.
-    result.push_back(Pair("masternode_payments_enforced", sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));
-    
+    // Else use Spork 8 to determine whether or not the Masternode payment is enforced.
+    else {
+        result.push_back(Pair("masternode_payments_enforced", sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));
+    }
     
     int nNextHeight = chainActive.Height() + 1;
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -775,7 +775,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("masternode_payments_started", pindexPrev->nHeight + 1 > Params().GetConsensus().nMasternodePaymentsStartBlock));
     
     // Masternodes must be paid with every block after block nHardForkTwo up to nHardForkFour which caused chain to fork
-    if (nHeight <= consensusParams.nHardForkFour) {
+    if ((pindexPrev->nHeight+1) <= consensusParams.nHardForkFour) {
         result.push_back(Pair("masternode_payments_enforced", true));
     }
     

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -775,7 +775,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("masternode_payments_started", pindexPrev->nHeight + 1 > Params().GetConsensus().nMasternodePaymentsStartBlock));
     
     // Masternodes must be paid with every block after block nHardForkTwo up to nHardForkFour which caused chain to fork
-    if (nBlockHeight <= consensusParams.nHardForkFour) {
+    if (nHeight <= consensusParams.nHardForkFour) {
         result.push_back(Pair("masternode_payments_enforced", true));
     }
     

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -774,15 +774,15 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("masternode", masternodeObj));
     result.push_back(Pair("masternode_payments_started", pindexPrev->nHeight + 1 > Params().GetConsensus().nMasternodePaymentsStartBlock));
     
-	// Masternodes must be paid with every block after block nHardForkTwo up to nHardForkFour which caused chain to fork
-	if (nBlockHeight <= consensusParams.nHardForkFour) {
-    	result.push_back(Pair("masternode_payments_enforced", true));
-	}
-	
-	// If Spork 8 is set then Masternode payment is enforced.
-	result.push_back(Pair("masternode_payments_enforced", sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));
-	
-		
+    // Masternodes must be paid with every block after block nHardForkTwo up to nHardForkFour which caused chain to fork
+    if (nBlockHeight <= consensusParams.nHardForkFour) {
+        result.push_back(Pair("masternode_payments_enforced", true));
+    }
+    
+    // If Spork 8 is set then Masternode payment is enforced.
+    result.push_back(Pair("masternode_payments_enforced", sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));
+    
+    
     int nNextHeight = chainActive.Height() + 1;
 
     // 0.5 CRDS reward to Dev fund from 625001 until block 1375000

--- a/src/version.h
+++ b/src/version.h
@@ -13,7 +13,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70005;
+static const int PROTOCOL_VERSION = 70006;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -22,7 +22,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 70000;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70004;
+static const int MIN_PEER_PROTO_VERSION = 70005;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
This version creates a fork at block 675000 that removes the coded enforcement of MN payments each block. Spork 8 is re-enabled to handle these and a warning is written to the log and block created without a MN payment if consensus can't be reached.

Version changed to 1.4.0.0
Protocol version incremented to 70006
Minimum peer version increased to 70005

